### PR TITLE
Add related_subject to PriorUse model

### DIFF
--- a/lib/corespring/prior_use.rb
+++ b/lib/corespring/prior_use.rb
@@ -1,7 +1,7 @@
 module CoreSpring
   class PriorUse < APIModel
     attr_accessor :contributor_name, :credentials, :grade_level, :source_url, :reviews_passed, :use, 
-                  :prior_use_other, :p_value, :primary_subject 
+                  :prior_use_other, :p_value, :primary_subject, :related_subject
 
     def initialize(attrs={})
       self.primary_subject = PrimarySubject.new(attrs.delete('primarySubject'))

--- a/spec/corespring/prior_use_spec.rb
+++ b/spec/corespring/prior_use_spec.rb
@@ -2,7 +2,11 @@ require 'spec_helper'
 
 describe "CoreSpring::PriorUse" do
   describe "#initialize" do
-    let(:attrs) { {'contributorName' => "Patrick", 'primarySubject' => {'id' => "asdf"}} }
+    let(:attrs) {{
+      'contributorName' => "Patrick",
+      'primarySubject' => {'id' => "asdf"},
+      'relatedSubject' => [],
+    }}
 
     subject { CoreSpring::PriorUse.new(attrs) }
 


### PR DESCRIPTION
`APIClient#get_item` currently fails with `NoMethodError: undefined method 'related_subject=' for #<CoreSpring::PriorUse:0x007f8b7a2b0f40>`.

This fix simply adds `related_subject` to the list of attr_accessors in `PriorUse`, matching the structure returned by the api endpoint.
