### PR TITLE
Add domain attribute to Standard model.

### DIFF
--- a/lib/corespring/standard.rb
+++ b/lib/corespring/standard.rb
@@ -1,6 +1,6 @@
 module CoreSpring
   class Standard < APIModel
-    attr_accessor :id, :dot_notation, :subject, :category, :sub_category, :standard, :grades
+    attr_accessor :id, :dot_notation, :subject, :category, :sub_category, :standard, :grades, :domain
   end
 end
 


### PR DESCRIPTION
Fixes `NoMethodError: undefined method 'domain=' for #<CoreSpring::Standard:0x007ff1044cebe8>` on `api_client.get_item`
